### PR TITLE
Debug:Monster가 Finish를 만나도 정상적으로 죽지 않던 버그 수정

### DIFF
--- a/Assets/Scripts/Managers/MonsterManager.cs
+++ b/Assets/Scripts/Managers/MonsterManager.cs
@@ -38,6 +38,7 @@ namespace MyGame.Managers
         {
             waveMonster.Enqueue(capsulePrefab);
             waveMonster.Enqueue(capsulePrefab);
+            Debug.Log($"몬스터 큐에 있는 몬스터 수 : {waveMonster.Count}");
         }
 
         public static int Hp = 100;
@@ -69,7 +70,7 @@ namespace MyGame.Managers
                 // Monster???? way ????
                 Monster monsterScript = newMonster.GetComponent<Monster>();
                 monsterScript.SetPath(pathHolder);
-
+                monsterScript.SetID(monsterID);
                 // monsterList.Add(newMonster);
                 // Change monsterList to monsterDict
                 monsterDict.Add(monsterID, newMonster);
@@ -96,6 +97,7 @@ namespace MyGame.Managers
             {
                 //Monster monsters1 = monster.GetComponent<Monster>();
                 //ResourceManager.Instance.addCoins(monsters1.GetReward());
+                
                 monsterDict.Remove((int)monsterID);
                 Destroy(monster);
             }


### PR DESCRIPTION
MonsterManager에서 Monster 인스턴스화 후 ID를 부여하지 않아
KillMonster에서 몬스터가 정상적으로 죽지 않던 버그를 
MonsterManager가 실제로 ID를 부여해서 제대로 Monster가 죽도록 fix.