### PR TITLE
Tower rogue logic

### DIFF
--- a/Assets/Scripts/Managers/TowerManager.cs
+++ b/Assets/Scripts/Managers/TowerManager.cs
@@ -29,7 +29,8 @@ namespace MyGame.Managers
                 Destroy(gameObject);
             }
         }
-        public void InstallTower(GameObject tower, Vector3 position)
+        // 설치한 타워의 ID 리턴하기로 변경. -> 타일의 초기화 위해.
+        public int InstallTower(GameObject tower, Vector3 position)
         {  // 설치할 타워까지 전달 받기로 변경.
             bool isEnough = StageManager.Instance.UseCoin(tower.GetComponent<Tower>().GetCost());
             //bool isEnough = true;
@@ -45,14 +46,14 @@ namespace MyGame.Managers
                     Debug.Log("타워 설치 실패");
                     // 설치 실패 사운드 재생
                     TowerSoundController.Instance.PlayFailedSound();
-                    return;
+                    return -1;
                 }
                 Debug.Log("타워 인스턴스화 성공");
                 if (!newTower.TryGetComponent<MonoBehaviour>(out var newTowerScript))   // 새 타워에서 스크립트 찾기.
                 {
                     Debug.Log("객체에 스크립트 존재하지 않음");
                     TowerSoundController.Instance.PlayFailedSound();    // 실패 사운드 재생.
-                    return;
+                    return -1;
                 }
                 // 타워 ID 세팅
                 newTowerScript.GetType()?.GetMethod("SetID", new Type[] { typeof(int) })?.Invoke(newTowerScript, new object[] { this.TowerIndex });
@@ -68,11 +69,12 @@ namespace MyGame.Managers
 
                 // 타워 설치 성공 사운드 재생
                 TowerSoundController.Instance.PlayInstallSound();
+                return newTower.GetComponent<Tower>().GetID();  // 설치한 타워 ID 리턴.
             }
             else
             {
                 TowerSoundController.Instance.PlayFailedSound();
-                return;
+                return -1;
             }
         }
 
@@ -149,11 +151,17 @@ namespace MyGame.Managers
             }
         }
 
+        // 타워 딕셔너리 반환.
+        public Dictionary<int, GameObject> GetTowerDict()
+        {
+            return this.towerDict;
+        }
+
         public void ResetRoguelike()
         {
             this.nDamage = 1f;
             this.mDamage = 0f;
-            
+
             this.globalSpeedModifier = 1f;
         }
 

--- a/Assets/Scripts/Managers/TowerManager.cs
+++ b/Assets/Scripts/Managers/TowerManager.cs
@@ -15,8 +15,6 @@ namespace MyGame.Managers
         [SerializeField, Tooltip("글로벌 공격력 증가 팩터 M")] private float mDamage = 0f;
         [SerializeField, Tooltip("글로벌 공격속도 증가 팩터 Speed")] private float globalSpeedModifier = 1f;
         private Dictionary<int, GameObject> towerDict = new Dictionary<int, GameObject>();  // 현재 소환 된 타워 리스트를 딕셔너리로 수정
-        private List<Vector3> towerSpawnPoints = new List<Vector3>();
-        private List<GameObject> availableTowers = new List<GameObject>();
 
         private int TowerIndex = 0;
         public static TowerManager Instance { get; private set; } // 싱글톤 패턴
@@ -84,13 +82,22 @@ namespace MyGame.Managers
             Debug.Log("Tower Selling");
             GameObject toDelete = towerDict[toDeleteID];
             Tower script = toDelete.GetComponent<Tower>();
-             StageManager.Instance.AddCoins(script.GetSellPrice());    // 구현되면 처리해야 함.
+            StageManager.Instance.AddCoins(script.GetSellPrice());    // 구현되면 처리해야 함.
             towerDict.Remove(toDeleteID);
             Destroy(toDelete);
             // 타워 판매 사운드 재생
             TowerSoundController.Instance.PlaySellSound();
         }
 
+        // 디버프 종류를 받아서 현재 존재하는 타워들에 추가하기. 추가할 종류가 여러개면 바깥에서 여러번 부르면 된다.
+        public void AddDebuffToAllTower(debuffBase dbuff)
+        {
+            // 현재 인스턴스화 된 타워 순환
+            foreach (var entry in towerDict)
+            {
+                entry.Value.GetComponent<Tower>().AddDebuff(dbuff); // 타워에 디버프 전달.
+            }
+        }
         public IEnumerable<GameObject> GetTowerPrefabs()
         {
             return this.towerPrefabs;

--- a/Assets/Scripts/Objects/Tower.cs
+++ b/Assets/Scripts/Objects/Tower.cs
@@ -63,8 +63,10 @@ namespace MyGame.Objects
 
         private void SetCylinderSize()
         {
-            // 실린더 크기 설정
-            float diameter = 2f * range;
+            // 실린더 크기 설정. 
+            // 실린더는 Prefab의 스케일 말고 월드 스케일에 영향을 받는 것이 좋으므로
+            // 현재 Prefab의 스케일로 나눠주는 것이 좋다.
+            float diameter = 2f * range / this.transform.localScale.x; // Prefab이 x, y, z 모두 같은 스케일로 증가한다고 가정.
             rangeCylinder.transform.localScale = new Vector3(diameter, 0.01f, diameter);
         }
         void Start()

--- a/Assets/Scripts/Objects/Tower.cs
+++ b/Assets/Scripts/Objects/Tower.cs
@@ -67,7 +67,8 @@ namespace MyGame.Objects
             // 실린더는 Prefab의 스케일 말고 월드 스케일에 영향을 받는 것이 좋으므로
             // 현재 Prefab의 스케일로 나눠주는 것이 좋다.
             float diameter = 2f * range / this.transform.localScale.x; // Prefab이 x, y, z 모두 같은 스케일로 증가한다고 가정.
-            rangeCylinder.transform.localScale = new Vector3(diameter, 0.01f, diameter);
+            // float yOffset = 0.1f / this.transform.localScale.y;    // 오프셋도 수정.
+            rangeCylinder.transform.localScale = new Vector3(diameter, 0, diameter);
         }
         void Start()
         {
@@ -137,6 +138,11 @@ namespace MyGame.Objects
             ShowRange();        // 사거리 표기.
             // 판매, 업그레이드 버튼 표기.
 
+            if (this.towerSelectUI != null) // Upgrade, Sell 버튼이 여러개 나오는 것 방지.
+            {
+                Destroy(this.towerSelectUI);
+            }
+            
             // Prefab 인스턴스 화.
             this.towerSelectUI = Instantiate(towerSelectUIPrefab);
             Vector3 uiPosition = this.transform.position;

--- a/Assets/Scripts/Objects/Tower.cs
+++ b/Assets/Scripts/Objects/Tower.cs
@@ -172,13 +172,21 @@ namespace MyGame.Objects
             return this.range;
         }
 
+        public void AddDebuff(debuffBase dbuff)
+        {
+            // 현재 디버프 종류에 전달 받은 디버프 추가하기.
+            this.debuffAssets.Add(dbuff);
+            // 실제 디버프 전달에 사용하는 리스트에도 추가하기.
+            this.debuffList.Add(Instantiate(dbuff));
+        }
+
         // 타워 업그레이드 로직.
         public bool UpgradeTower()
         {
             // 타워 레벨 업그레이드 용 함수.
             // Case 1 : 돈이 충분해서 업그레이드 성공 == stat 업데이트 하고 true 리턴
             // Case 2 : 업그레이드 실패 == false 리턴
-             bool upgradeAble = StageManager.Instance.UseCoin(this.upgradeCost);
+            bool upgradeAble = StageManager.Instance.UseCoin(this.upgradeCost);
             //bool upgradeAble = true;    // 테스트용. 고쳐야 함.
             // bool upgradeAble = false;    // 테스트용. 고쳐야 함.
 

--- a/Assets/Scripts/Objects/Tower.cs
+++ b/Assets/Scripts/Objects/Tower.cs
@@ -146,7 +146,8 @@ namespace MyGame.Objects
             // Prefab 인스턴스 화.
             this.towerSelectUI = Instantiate(towerSelectUIPrefab);
             Vector3 uiPosition = this.transform.position;
-            uiPosition.y += 4;
+            // uiPosition.y += 4;
+            uiPosition.y += 5 * this.transform.localScale.y;    // 타워 Prefab 스케일에 따라 생성 높이 차등 적용
             towerSelectUI.transform.position = uiPosition;
             this.modifyLogic = towerSelectUI.GetComponent<UpgradeSellLogic>();
 

--- a/Assets/Scripts/Objects/TowerPlacementTile.cs
+++ b/Assets/Scripts/Objects/TowerPlacementTile.cs
@@ -10,7 +10,7 @@ public class TowerPlacementTile : MonoBehaviour
     [SerializeField, Tooltip("마우스 On 시 색상")] private Color hoverColor = Color.red;
     [SerializeField, Tooltip("타일 위치")] private Vector3 tilePosition;
     [SerializeField, Tooltip("타일에 설치할 타워 종류")] public static GameObject towerPrefab;
-    
+    [SerializeField, Tooltip("타일에 설치할 타워 종류")] private int towerID;
 
     private Renderer rend;  // 타일의 랜더러 컴포넌트 저장용.
     private Color originalColor;
@@ -34,6 +34,15 @@ public class TowerPlacementTile : MonoBehaviour
     // 마우스가 타일에 올라오면 색상 변경.
     void OnMouseEnter()
     {
+        if (towerID != -1)  // 내 타일 위에 성공적으로 설치된 타워가 있었다면
+        {
+            TowerManager.Instance.GetTowerDict().TryGetValue(towerID, out GameObject tower);
+            if (tower == null)  // 내 ID에 해당하는 타워가 살아있지 않으면 원상복구.
+            {
+                towerID = -1;
+                canBuild = true;
+            }
+        }
         if (!TowerManager.Instance.GetMode())
         {
             //Debug.Log("설치 모드가 아닙니다.");
@@ -74,7 +83,7 @@ public class TowerPlacementTile : MonoBehaviour
         }
         // 현재 타일 위치 타워 매니저에 전달해서 타워 설치 요청.
         Vector3 installPosition = this.tilePosition + offset;
-        TowerManager.Instance.InstallTower(towerPrefab, installPosition);
+        towerID = TowerManager.Instance.InstallTower(towerPrefab, installPosition); // 아이디 저장.
 
         // 타워 설치 완료 시 이 타일에는 다른 타워를 놓을 수 없다.
         this.canBuild = false;


### PR DESCRIPTION
1. TowerManager.Instace.AddDebuffToAllTower(debuffBase db); 추가 - 타워 디버프 추가 로그라이크 로직
2. 타워 사거리 표시가 타워 Prefab의 스케일 증가를 고려하지 않던 문제 수정.
3. 타워 Upgrade, Sell 버튼 위치를 타워 스케일에 영향 받도록 수정.
4. 타워 Upgrade, Sell 버튼이 타워 판매 후 남을 수 있는 문제 수정
5. 타일 위의 타워를 판매하고서 해당 타일에 타워를 다시 건설할 수 없었던 문제 수정.