### PR TITLE
로그라이크 카드 오류 수정, 신규 로그라이크 기능 추가, 씬과 Prefab 수정

### DIFF
--- a/Assets/Prefabs/UI/InStageCanvas.prefab
+++ b/Assets/Prefabs/UI/InStageCanvas.prefab
@@ -84,11 +84,11 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6346380469988122076}
+  - component: {fileID: 786956860361013241}
   - component: {fileID: 7059375597249488777}
   - component: {fileID: 6069332998473108946}
   - component: {fileID: 5451604631265438421}
   - component: {fileID: 4510561829314233161}
-  - component: {fileID: 74753311546897547}
   m_Layer: 5
   m_Name: InStageCanvas
   m_TagString: Untagged
@@ -124,6 +124,51 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &786956860361013241
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 611178982825644569}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a01b2c6eab825de4fa911167a03b9d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  upgradeMenuPanel: {fileID: 6848299493925052664}
+  optionButtons:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  RLCard: {fileID: 8985209106428996900, guid: eb0969b9e407bb74598bfda1a697fa3b, type: 3}
+  allUpgrades:
+  - {fileID: 11400000, guid: 9832bcf84bd9aae4e886abafbcc454bf, type: 2}
+  - {fileID: 11400000, guid: 664ffa454f15b9f4388a935452759389, type: 2}
+  - {fileID: 11400000, guid: 7272617a491c8e54bb41198bea60e1fc, type: 2}
+  - {fileID: 11400000, guid: 3fe0a4bc4cb64fa42b36ae47f6620c7b, type: 2}
+  - {fileID: 11400000, guid: a6b6fb7bc6c1bcb4eb6799d5a6a9da19, type: 2}
+  - {fileID: 11400000, guid: 45cc501c5aa15104197124f4bbf932e2, type: 2}
+  - {fileID: 11400000, guid: 57d9b910ded21134e8811e8659b864cb, type: 2}
+  - {fileID: 11400000, guid: 0aff09e7d9c5c6b49b3a6729b91267b9, type: 2}
+  - {fileID: 11400000, guid: 759e4ffd79a95c242853d9ff7f01e2ec, type: 2}
+  - {fileID: 11400000, guid: 94aaffa523321424a82856d353e0039b, type: 2}
+  - {fileID: 11400000, guid: cb9cd84413405144eb4b059752b46652, type: 2}
+  - {fileID: 11400000, guid: 7aad32908870c8e4c9403651c5e6179a, type: 2}
+  - {fileID: 11400000, guid: 3dd9c7d609d950d4aaf5a9a416f0301c, type: 2}
+  - {fileID: 11400000, guid: 94a4597bad9686e4383554afdf70f986, type: 2}
+  - {fileID: 11400000, guid: 07f3613be34192b44a08767f0d6e4d99, type: 2}
+  - {fileID: 11400000, guid: 1b2d6181cf7d2304ab4b8170b6d00b6c, type: 2}
+  - {fileID: 11400000, guid: c69038d938f7f7a4f9c81cdd434d9c40, type: 2}
+  - {fileID: 11400000, guid: 1c6788f3bdb5350438b870391f90487c, type: 2}
+  - {fileID: 11400000, guid: 31e58ae1ee5c02749bb3c37a2b74df37, type: 2}
+  - {fileID: 11400000, guid: 2547af63cf709f5498ddb0405f032db4, type: 2}
+  - {fileID: 11400000, guid: be107cabcb95f1a43b119ecb7780d7b7, type: 2}
+  - {fileID: 11400000, guid: 021677e8b875df742b22de70580e3b60, type: 2}
+  - {fileID: 11400000, guid: 56d332603a204f143937f498e0e2595c, type: 2}
+  - {fileID: 11400000, guid: ca881d6dd77e1a24e9b711e36199d2d4, type: 2}
+  - {fileID: 11400000, guid: e812cbede5389b44e9f999f5847dcd6f, type: 2}
+  - {fileID: 11400000, guid: 2875b983288fc3443832313113f3f3c1, type: 2}
 --- !u!223 &7059375597249488777
 Canvas:
   m_ObjectHideFlags: 0
@@ -199,29 +244,6 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
---- !u!114 &74753311546897547
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 611178982825644569}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a01b2c6eab825de4fa911167a03b9d0a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  upgradeMenuPanel: {fileID: 6848299493925052664}
-  optionButtons:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  RLCard: {fileID: 8985209106428996900, guid: eb0969b9e407bb74598bfda1a697fa3b, type: 3}
-  allUpgrades:
-  - {fileID: 11400000, guid: 9832bcf84bd9aae4e886abafbcc454bf, type: 2}
-  - {fileID: 11400000, guid: 94aaffa523321424a82856d353e0039b, type: 2}
-  - {fileID: 11400000, guid: be107cabcb95f1a43b119ecb7780d7b7, type: 2}
-  - {fileID: 11400000, guid: ca881d6dd77e1a24e9b711e36199d2d4, type: 2}
 --- !u!1 &668039957643912587
 GameObject:
   m_ObjectHideFlags: 0
@@ -511,7 +533,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 391915669a4cb00468d053336d4a1d59, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  monsterInfoBtn: {fileID: 668039957643912587}
+  monsterInfoPanelObject: {fileID: 0}
   imageTemplate: {fileID: 8536843269357291896, guid: 40df48d7ea00d3f4f8b70a79ea5187a5, type: 3}
   monsterDex: {fileID: 11400000, guid: d430a3054f1f301409d703de8a0b7c74, type: 2}
 --- !u!1 &1568844617181250464
@@ -1961,9 +1983,9 @@ RectTransform:
   - {fileID: 4694601220785953769}
   m_Father: {fileID: 6346380469988122076}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -594, y: -119}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 200, y: -123.24331}
   m_SizeDelta: {x: 400, y: 130}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &9031039327467472157
@@ -1994,7 +2016,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300020, guid: 1eaee135ce037439d925cee5e41ce026, type: 3}
+  m_Sprite: {fileID: -795542533, guid: 7f5e833b25b5fed4a85ad9db3d65dea9, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Scenes/InStage.unity
+++ b/Assets/Scenes/InStage.unity
@@ -952,7 +952,6 @@ Transform:
   m_Children:
   - {fileID: 1876513262}
   - {fileID: 753593326}
-  - {fileID: 1887993793}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &963194225
@@ -1128,11 +1127,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 98123295593672910, guid: c6ea3f27feafbb94f8e31e379306b122, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 400
       objectReference: {fileID: 0}
     - target: {fileID: 98123295593672910, guid: c6ea3f27feafbb94f8e31e379306b122, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 130
       objectReference: {fileID: 0}
     - target: {fileID: 611178982825644569, guid: c6ea3f27feafbb94f8e31e379306b122, type: 3}
       propertyPath: m_Name
@@ -1236,7 +1235,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7674317188693773295, guid: c6ea3f27feafbb94f8e31e379306b122, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -2767,94 +2766,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1884696363}
   m_CullTransparentMesh: 1
---- !u!1 &1887993792
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1887993793}
-  - component: {fileID: 1887993795}
-  - component: {fileID: 1887993794}
-  m_Layer: 0
-  m_Name: RoguelikeManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1887993793
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1887993792}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 952500861}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1887993794
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1887993792}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a01b2c6eab825de4fa911167a03b9d0a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  upgradeMenuPanel: {fileID: 1066721093}
-  optionButtons:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  RLCard: {fileID: 8985209106428996900, guid: eb0969b9e407bb74598bfda1a697fa3b, type: 3}
-  allUpgrades:
-  - {fileID: 11400000, guid: 9832bcf84bd9aae4e886abafbcc454bf, type: 2}
-  - {fileID: 11400000, guid: 664ffa454f15b9f4388a935452759389, type: 2}
-  - {fileID: 11400000, guid: 7272617a491c8e54bb41198bea60e1fc, type: 2}
-  - {fileID: 11400000, guid: 3fe0a4bc4cb64fa42b36ae47f6620c7b, type: 2}
-  - {fileID: 11400000, guid: a6b6fb7bc6c1bcb4eb6799d5a6a9da19, type: 2}
-  - {fileID: 11400000, guid: 45cc501c5aa15104197124f4bbf932e2, type: 2}
-  - {fileID: 11400000, guid: 57d9b910ded21134e8811e8659b864cb, type: 2}
-  - {fileID: 11400000, guid: 0aff09e7d9c5c6b49b3a6729b91267b9, type: 2}
-  - {fileID: 11400000, guid: 759e4ffd79a95c242853d9ff7f01e2ec, type: 2}
-  - {fileID: 11400000, guid: 94aaffa523321424a82856d353e0039b, type: 2}
-  - {fileID: 11400000, guid: cb9cd84413405144eb4b059752b46652, type: 2}
-  - {fileID: 11400000, guid: 7aad32908870c8e4c9403651c5e6179a, type: 2}
-  - {fileID: 11400000, guid: 3dd9c7d609d950d4aaf5a9a416f0301c, type: 2}
-  - {fileID: 11400000, guid: 94a4597bad9686e4383554afdf70f986, type: 2}
-  - {fileID: 11400000, guid: 07f3613be34192b44a08767f0d6e4d99, type: 2}
-  - {fileID: 11400000, guid: 1c6788f3bdb5350438b870391f90487c, type: 2}
-  - {fileID: 11400000, guid: 31e58ae1ee5c02749bb3c37a2b74df37, type: 2}
-  - {fileID: 11400000, guid: 2547af63cf709f5498ddb0405f032db4, type: 2}
-  - {fileID: 11400000, guid: be107cabcb95f1a43b119ecb7780d7b7, type: 2}
-  - {fileID: 11400000, guid: 021677e8b875df742b22de70580e3b60, type: 2}
-  - {fileID: 11400000, guid: 56d332603a204f143937f498e0e2595c, type: 2}
-  - {fileID: 11400000, guid: ca881d6dd77e1a24e9b711e36199d2d4, type: 2}
-  - {fileID: 11400000, guid: e812cbede5389b44e9f999f5847dcd6f, type: 2}
-  - {fileID: 11400000, guid: 2875b983288fc3443832313113f3f3c1, type: 2}
---- !u!225 &1887993795
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1887993792}
-  m_Enabled: 1
-  m_Alpha: 1
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 0
 --- !u!1 &2116301425
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/RogueLike/RoguelikeManager.cs
+++ b/Assets/Scripts/RogueLike/RoguelikeManager.cs
@@ -48,7 +48,7 @@ public class RoguelikeManager : MonoBehaviour
         this.accDecreaseFlatSpeed = 0;
         this.accDecreasePercentSpeed = 1;
         this.accExtraCoin = 0;
-        
+
         MonsterManager.Instance.ResetRoguelike();
         TowerManager.Instance.ResetRoguelike();
     }
@@ -162,6 +162,16 @@ public class RoguelikeManager : MonoBehaviour
                 this.increaseDamageValue(selected);
                 break;
 
+            // GetInstantCoin
+            case 8:
+                this.GetInstantCoin(selected);
+                break;
+
+            // GetInstantHealth
+            case 9:
+                this.GetInstantHealth(selected);
+                break;
+
             default:
                 Debug.Log($"ID가 등록되지 않았거나 잘못된 ID 입니다. ID : {selected.rogueID}");
                 break;
@@ -203,18 +213,28 @@ public class RoguelikeManager : MonoBehaviour
         MonsterManager.Instance.SetExtraCoin((int)selected.value);
     }
 
-    public void increaseAttackSpeed(RogueUpgrade selected){
+    public void increaseAttackSpeed(RogueUpgrade selected)
+    {
         TowerManager.Instance.SetAttackSpeedIncrease(1f + selected.value);
     }
-    
+
     public void increaseDamagePercent(RogueUpgrade selected)
     {
         TowerManager.Instance.SetDamageIncrease(selected.value, 0);
     }
-    
+
     public void increaseDamageValue(RogueUpgrade selected)
     {
         TowerManager.Instance.SetDamageIncrease(0, selected.value);
     }
+
+    public void GetInstantCoin(RogueUpgrade selected)
+    {
+        StageManager.Instance.AddCoins((int)selected.value);
+    }
+    public void GetInstantHealth(RogueUpgrade selected)
+    {
+        StageManager.Instance.TakeDamage(-(int)selected.value);
+    }    
 
 }

--- a/Assets/Scripts/RogueLike/RoguelikeManager.cs
+++ b/Assets/Scripts/RogueLike/RoguelikeManager.cs
@@ -104,6 +104,19 @@ public class RoguelikeManager : MonoBehaviour
         // }
     }
 
+    private void DestroyRLCards()
+    {
+        // 로그라이크 카드 파괴
+        RLCard[] cardList = GetComponentsInChildren<RLCard>();
+        foreach (var cardScript in cardList)
+        {
+            Destroy(cardScript.gameObject);
+        }
+
+        // optionButtons 다시 빈 배열로
+        this.optionButtons = new Button[3];
+    }
+
     private void OnUpgradeSelected(RogueUpgrade selected)
     {
         // 실제 업그레이드 적용 로직
@@ -154,7 +167,8 @@ public class RoguelikeManager : MonoBehaviour
                 break;
         }
 
-        // 메뉴 숨기기
+        // 로그라이크 카드들 Perge 하고 메뉴 숨기기
+        DestroyRLCards();
         upgradeMenuPanel.SetActive(false);
         // _canvasGroup.interactable = false;
         // _canvasGroup.blocksRaycasts = false;

--- a/Assets/Scripts/RogueLike/upgrades/GetInstantCoin1.asset
+++ b/Assets/Scripts/RogueLike/upgrades/GetInstantCoin1.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e14f68163a283054ea881206304a19ab, type: 3}
+  m_Name: GetInstantCoin1
+  m_EditorClassIdentifier: 
+  upgradeName: "\uCF54\uC778 \uD68D\uB4DD 1"
+  rogueID: 8
+  description: "\uC120\uD0DD \uC989\uC2DC\nN \uCF54\uC778  \uD68D\uB4DD"
+  minValue: 10
+  maxValue: 15
+  isPercent: 0
+  Icon: {fileID: 0}
+  value: 4

--- a/Assets/Scripts/RogueLike/upgrades/GetInstantCoin1.asset.meta
+++ b/Assets/Scripts/RogueLike/upgrades/GetInstantCoin1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1b2d6181cf7d2304ab4b8170b6d00b6c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/RogueLike/upgrades/GetInstantHealth1.asset
+++ b/Assets/Scripts/RogueLike/upgrades/GetInstantHealth1.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e14f68163a283054ea881206304a19ab, type: 3}
+  m_Name: GetInstantHealth1
+  m_EditorClassIdentifier: 
+  upgradeName: "\uCCB4\uB825 \uD68D\uB4DD 1"
+  rogueID: 9
+  description: "\uC120\uD0DD \uC989\uC2DC\nN \uCCB4\uB825 \uD68D\uB4DD"
+  minValue: 10
+  maxValue: 15
+  isPercent: 0
+  Icon: {fileID: 0}
+  value: 4

--- a/Assets/Scripts/RogueLike/upgrades/GetInstantHealth1.asset.meta
+++ b/Assets/Scripts/RogueLike/upgrades/GetInstantHealth1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c69038d938f7f7a4f9c81cdd434d9c40
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
1. RoguelikeManager 수정해서 RLPanel 사라질 때 카드들 파괴하도록 수정
2. RoguelikeManager 오브젝트 삭제하고 InStageCanvas Prefab에 RoguelikeManager.cs 적용 시킴 (카드 쉽게 없애려고)
3. 2번으로 인한 Prefab과 씬 수정
4. 스테이지 Prefab 이름이 stageMap이 아니고 StageMap으로 저장되어 있어서 다시 수정